### PR TITLE
Fix error in SimulationContext >> #runUntilErrorOrReturnFrom:

### DIFF
--- a/packages/SimulationStudio-Base.package/SimulationContext.class/instance/runUntilErrorOrReturnFrom..st
+++ b/packages/SimulationStudio-Base.package/SimulationContext.class/instance/runUntilErrorOrReturnFrom..st
@@ -13,14 +13,11 @@ runUntilErrorOrReturnFrom: homeContext
 	error := nil.
 	[:exit | [
 		error ifNil: [
-			ctxt closure
-				caseOf: {
-					[errorBlock] -> [
-						error := (ctxt tempAt: 1) exception.
-						exit value].
-					[ensureBlock] -> [
-						exit value] }
-				otherwise: []].
+			ctxt closure == errorBlock ifTrue: [
+				error := (ctxt tempAt: 1) exception.
+				exit value].
+			ctxt closure == ensureBlock ifTrue: [
+				exit value]].
 		ctxt := ctxt step
 	] repeat] valueWithExit.
 	

--- a/packages/SimulationStudio-Base.package/SimulationContext.class/methodProperties.json
+++ b/packages/SimulationStudio-Base.package/SimulationContext.class/methodProperties.json
@@ -29,7 +29,7 @@
 		"push:" : "ct 12/28/2020 19:07",
 		"runSimulated:" : "ct 1/10/2021 20:14",
 		"runSimulated:contextAtEachStep:" : "ct 3/15/2021 12:06",
-		"runUntilErrorOrReturnFrom:" : "ct 3/14/2021 15:33",
+		"runUntilErrorOrReturnFrom:" : "ct 3/19/2021 20:01",
 		"shouldNotImplement:" : "ct 12/28/2020 15:29",
 		"size" : "ct 12/28/2020 19:14",
 		"stackp:" : "ct 12/28/2020 19:13",


### PR DESCRIPTION
Confusingly, `#caseOf:otherwise:` does not check the receiver and the passed associations' keys' block values for identity but for equality. This caused the simulation loop to stop too early when certain #ensure: contexts were reached. The rest of the simulation was then run in the `#stepToCallee` loop where every `UnhandledError` would be resumed without aborting the simulation.

Closes #10.