### PR TITLE
Simplify SimulationContext>>#runUntilErrorOrReturnFrom:

### DIFF
--- a/packages/SimulationStudio-Base.package/SimulationContext.class/instance/runUntilErrorOrReturnFrom..st
+++ b/packages/SimulationStudio-Base.package/SimulationContext.class/instance/runUntilErrorOrReturnFrom..st
@@ -12,12 +12,11 @@ runUntilErrorOrReturnFrom: homeContext
 	ctxt := self.
 	error := nil.
 	[:exit | [
-		error ifNil: [
-			ctxt closure == errorBlock ifTrue: [
-				error := (ctxt tempAt: 1) exception.
-				exit value].
-			ctxt closure == ensureBlock ifTrue: [
-				exit value]].
+		ctxt closure == errorBlock ifTrue: [
+			error := (ctxt tempAt: 1) exception.
+			exit value].
+		ctxt closure == ensureBlock ifTrue: [
+			exit value].
 		ctxt := ctxt step
 	] repeat] valueWithExit.
 	

--- a/packages/SimulationStudio-Base.package/SimulationContext.class/methodProperties.json
+++ b/packages/SimulationStudio-Base.package/SimulationContext.class/methodProperties.json
@@ -29,7 +29,7 @@
 		"push:" : "ct 12/28/2020 19:07",
 		"runSimulated:" : "ct 1/10/2021 20:14",
 		"runSimulated:contextAtEachStep:" : "ct 3/15/2021 12:06",
-		"runUntilErrorOrReturnFrom:" : "ct 3/19/2021 20:01",
+		"runUntilErrorOrReturnFrom:" : "ct 3/28/2021 12:10",
 		"shouldNotImplement:" : "ct 12/28/2020 15:29",
 		"size" : "ct 12/28/2020 19:14",
 		"stackp:" : "ct 12/28/2020 19:13",


### PR DESCRIPTION
`error` will be always nil in the `#repeat` loop. Thanks to Balázs Kósi for pointing this out! [1]

[1] http://forum.world.st/identityCaseOf-tp5128090p5128096.html