### PR TITLE
Fix `#customize:`

### DIFF
--- a/packages/SimulationStudio-Base.package/SimulationContext.class/instance/customize..st
+++ b/packages/SimulationStudio-Base.package/SimulationContext.class/instance/customize..st
@@ -3,5 +3,6 @@ customize: aContext
 	"Answer a version of aContext that is converted to the class of the receiver."
 
 	aContext == self ifTrue: [^ aContext].
+	aContext ifNil: [^ nil].
 	(aContext isKindOf: self class) ifTrue: [^ aContext].
 	^ self basicCustomize: aContext

--- a/packages/SimulationStudio-Base.package/SimulationContext.class/methodProperties.json
+++ b/packages/SimulationStudio-Base.package/SimulationContext.class/methodProperties.json
@@ -20,7 +20,7 @@
 		"basicCustomize:" : "ct 3/14/2021 15:20",
 		"basicSize" : "ct 3/5/2021 19:18",
 		"copyFrom:" : "ct 3/2/2021 23:01",
-		"customize:" : "ct 3/14/2021 15:21",
+		"customize:" : "ct 1/7/2022 22:08",
 		"decustomize:" : "ct 3/20/2021 15:35",
 		"findNextHandlerContextStarting" : "ct 12/29/2020 15:05",
 		"findNextUnwindContextUpTo:" : "ct 12/29/2020 20:15",

--- a/packages/SimulationStudio-Base.package/Simulator.class/instance/customize..st
+++ b/packages/SimulationStudio-Base.package/Simulator.class/instance/customize..st
@@ -1,0 +1,9 @@
+support
+customize: aContext
+
+	^ self
+		basicSimulate: []
+		do: [:contextClass :simulator :theBlock |
+			(contextClass newFrom: aContext sender)
+				simulator: simulator;
+				customize: aContext]

--- a/packages/SimulationStudio-Base.package/Simulator.class/methodProperties.json
+++ b/packages/SimulationStudio-Base.package/Simulator.class/methodProperties.json
@@ -58,6 +58,7 @@
 		"context:storeIntoRemoteTemp:inVectorAt:do:" : "ct 11/13/2021 15:44",
 		"context:storeIntoTemporaryVariable:do:" : "ct 11/13/2021 15:44",
 		"context:tryNamedPrimitiveIn:for:withArgs:do:" : "ct 11/13/2021 15:19",
+		"customize:" : "ct 1/7/2022 20:02",
 		"debug:" : "ct 11/13/2021 17:06",
 		"evaluate:" : "ct 11/13/2021 17:06",
 		"initializeContext:" : "ct 11/13/2021 00:19",

--- a/packages/SimulationStudio-Tests-Base.package/SimulationContextTest.class/instance/testReturnFromBottom.st
+++ b/packages/SimulationStudio-Tests-Base.package/SimulationContextTest.class/instance/testReturnFromBottom.st
@@ -1,0 +1,7 @@
+tests
+testReturnFromBottom
+
+	| context |
+	context := SimulationContext newFrom: [] asContext.
+	
+	self assert: context step isNil.

--- a/packages/SimulationStudio-Tests-Base.package/SimulationContextTest.class/methodProperties.json
+++ b/packages/SimulationStudio-Tests-Base.package/SimulationContextTest.class/methodProperties.json
@@ -18,4 +18,5 @@
 		"testMirrorClone" : "ct 12/29/2021 14:44",
 		"testMirrorWriteBarrier" : "ct 12/29/2021 14:45",
 		"testObjectIdentityHash" : "ct 12/28/2021 17:37",
+		"testReturnFromBottom" : "ct 1/7/2022 22:08",
 		"testWrap" : "ct 3/24/2021 23:51" } }


### PR DESCRIPTION
- Fix `SimulationContext >> #customize:` for bottom contexts (b3688b21b6fa61a482e44ef47490af484af28207)
- Add `Simulator >> #customize:` (d3d5fcccb95ab35bfc7552f6d03eb21ed03899f9)