### PR TITLE
Some more fixes

### DIFF
--- a/packages/SimulationStudio-Base.package/SimulationContext.class/instance/runSimulated.contextAtEachStep..st
+++ b/packages/SimulationStudio-Base.package/SimulationContext.class/instance/runSimulated.contextAtEachStep..st
@@ -3,6 +3,8 @@ runSimulated: aBlock contextAtEachStep: anotherBlock
 	"Copied from super. Details: Use #customize: before starting the simulation and convert back to simple context at the end."
 
 	| home current resume ensure |
+	self flag: #moveUpstream. "But what?"
+	
 	home := thisContext home sender.
 	resume := false.
 	"Affect the context stack of the receiver during the simulation of aBlock."
@@ -14,9 +16,15 @@ runSimulated: aBlock contextAtEachStep: anotherBlock
 		self flag: #todo. "terminate some contexts from previous sender here?"
 		ensure := thisContext sender.
 		home
-			push: ((ensure selector == #resume: or: [ensure selector == #resume:through:])
-				ifTrue: [ensure at: 1]
-				ifFalse: [ensure at: 3]) "returnValue";
+			push: (ensure selector
+				caseOf:
+					{[#resume:through:] -> [ensure at: 1 "value"].
+					[#resumeEvaluating:] ->
+						[| resumeBlock |
+						resumeBlock := ensure at: 1 "aBlock".
+						self assert: resumeBlock outerContext selector == #resume:. "other sender #returnEvaluating: is only sent to signaler contexts"
+						resumeBlock value]}
+				otherwise: [(ensure "BlockClosure >> #ensure: or BlockClosure >> #ifCurtailed:" at: 3) "returnValue"]);
 			jump].
 	
 	current := self customize: current.

--- a/packages/SimulationStudio-Base.package/SimulationContext.class/instance/size.st
+++ b/packages/SimulationStudio-Base.package/SimulationContext.class/instance/size.st
@@ -1,4 +1,4 @@
 accessing - stack patching
 size
 
-	^ stack size
+	^ stackp

--- a/packages/SimulationStudio-Base.package/SimulationContext.class/instance/tempAt..st
+++ b/packages/SimulationStudio-Base.package/SimulationContext.class/instance/tempAt..st
@@ -1,0 +1,4 @@
+accessing - stack patching
+tempAt: index
+
+	^ stack at: index

--- a/packages/SimulationStudio-Base.package/SimulationContext.class/instance/tempAt.put..st
+++ b/packages/SimulationStudio-Base.package/SimulationContext.class/instance/tempAt.put..st
@@ -1,0 +1,4 @@
+accessing - stack patching
+tempAt: index put: value
+
+	^ stack at: index put: value

--- a/packages/SimulationStudio-Base.package/SimulationContext.class/methodProperties.json
+++ b/packages/SimulationStudio-Base.package/SimulationContext.class/methodProperties.json
@@ -36,7 +36,9 @@
 		"runUntilErrorOrReturnFrom:" : "ct 3/28/2021 12:10",
 		"send:to:with:lookupIn:" : "ct 12/29/2021 14:52",
 		"shouldNotImplement:" : "ct 12/28/2020 15:29",
-		"size" : "ct 12/28/2020 19:14",
+		"size" : "ct 1/9/2022 21:54",
 		"stackp:" : "ct 11/11/2021 19:14",
 		"step" : "ct 11/13/2021 19:45",
+		"tempAt:" : "ct 1/21/2022 03:41",
+		"tempAt:put:" : "ct 1/21/2022 03:41",
 		"tryNamedPrimitiveIn:for:withArgs:" : "ct 11/18/2021 11:14" } }

--- a/packages/SimulationStudio-Base.package/SimulationContext.class/methodProperties.json
+++ b/packages/SimulationStudio-Base.package/SimulationContext.class/methodProperties.json
@@ -32,7 +32,7 @@
 		"printOn:" : "ct 12/28/2020 15:49",
 		"push:" : "ct 12/28/2020 19:07",
 		"runSimulated:" : "ct 1/10/2021 20:14",
-		"runSimulated:contextAtEachStep:" : "ct 3/15/2021 12:06",
+		"runSimulated:contextAtEachStep:" : "ct 1/23/2022 01:22",
 		"runUntilErrorOrReturnFrom:" : "ct 3/28/2021 12:10",
 		"send:to:with:lookupIn:" : "ct 12/29/2021 14:52",
 		"shouldNotImplement:" : "ct 12/28/2020 15:29",

--- a/packages/SimulationStudio-Support.package/LimitSimulator.class/instance/context.step..st
+++ b/packages/SimulationStudio-Support.package/LimitSimulator.class/instance/context.step..st
@@ -3,6 +3,6 @@ context: aContext step: aBlock
 
 	stepCount := stepCount + 1.
 	stepCount >= stepLimit ifTrue: [
-		SimulatorLimitExceeded signal].
+		SimulatorLimitExceeded signalForContext: aContext].
 	
 	^ super context: aContext step: aBlock

--- a/packages/SimulationStudio-Support.package/LimitSimulator.class/instance/stepCount.st
+++ b/packages/SimulationStudio-Support.package/LimitSimulator.class/instance/stepCount.st
@@ -1,0 +1,4 @@
+accessing
+stepCount
+
+	^ stepCount

--- a/packages/SimulationStudio-Support.package/LimitSimulator.class/methodProperties.json
+++ b/packages/SimulationStudio-Support.package/LimitSimulator.class/methodProperties.json
@@ -2,7 +2,8 @@
 	"class" : {
 		 },
 	"instance" : {
-		"context:step:" : "ct 11/13/2021 17:31",
+		"context:step:" : "ct 1/22/2022 14:33",
 		"initialize" : "ct 11/13/2021 00:08",
+		"stepCount" : "ct 1/22/2022 14:54",
 		"stepLimit" : "ct 11/13/2021 00:09",
 		"stepLimit:" : "ct 11/13/2021 00:09" } }

--- a/packages/SimulationStudio-Support.package/SimulatorLimitExceeded.class/class/forContext..st
+++ b/packages/SimulationStudio-Support.package/SimulatorLimitExceeded.class/class/forContext..st
@@ -1,0 +1,6 @@
+instance creation
+forContext: aContext
+
+	^ self new
+		context: aContext;
+		yourself

--- a/packages/SimulationStudio-Support.package/SimulatorLimitExceeded.class/class/signalForContext..st
+++ b/packages/SimulationStudio-Support.package/SimulatorLimitExceeded.class/class/signalForContext..st
@@ -1,0 +1,4 @@
+signaling
+signalForContext: aContext
+
+	^ (self forContext: aContext) signal

--- a/packages/SimulationStudio-Support.package/SimulatorLimitExceeded.class/instance/context..st
+++ b/packages/SimulationStudio-Support.package/SimulatorLimitExceeded.class/instance/context..st
@@ -1,0 +1,4 @@
+accessing
+context: aContext
+
+	context := aContext

--- a/packages/SimulationStudio-Support.package/SimulatorLimitExceeded.class/instance/context.st
+++ b/packages/SimulationStudio-Support.package/SimulatorLimitExceeded.class/instance/context.st
@@ -1,0 +1,4 @@
+accessing
+context
+
+	^ context

--- a/packages/SimulationStudio-Support.package/SimulatorLimitExceeded.class/instance/isResumable.st
+++ b/packages/SimulationStudio-Support.package/SimulatorLimitExceeded.class/instance/isResumable.st
@@ -1,0 +1,4 @@
+testing
+isResumable
+
+	^ true

--- a/packages/SimulationStudio-Support.package/SimulatorLimitExceeded.class/methodProperties.json
+++ b/packages/SimulationStudio-Support.package/SimulatorLimitExceeded.class/methodProperties.json
@@ -1,5 +1,8 @@
 {
 	"class" : {
-		 },
+		"forContext:" : "ct 1/22/2022 14:33",
+		"signalForContext:" : "ct 1/22/2022 14:33" },
 	"instance" : {
-		 } }
+		"context" : "ct 1/22/2022 14:32",
+		"context:" : "ct 1/22/2022 14:32",
+		"isResumable" : "ct 1/22/2022 14:36" } }

--- a/packages/SimulationStudio-Support.package/SimulatorLimitExceeded.class/properties.json
+++ b/packages/SimulationStudio-Support.package/SimulatorLimitExceeded.class/properties.json
@@ -6,7 +6,7 @@
 		 ],
 	"commentStamp" : "",
 	"instvars" : [
-		 ],
+		"context" ],
 	"name" : "SimulatorLimitExceeded",
 	"pools" : [
 		 ],

--- a/packages/SimulationStudio-Tests-Base.package/SimulationContextTest.class/instance/testExceptionHandlerAroundSimulator.st
+++ b/packages/SimulationStudio-Tests-Base.package/SimulationContextTest.class/instance/testExceptionHandlerAroundSimulator.st
@@ -1,0 +1,16 @@
+tests
+testExceptionHandlerAroundSimulator
+
+	| error |
+	[SimulationContext runSimulated: [Error new tag: self; signal]]
+		on: Error
+		do: [:ex | error := ex].
+	self
+		assert: error notNil;
+		assert: self identical: error tag.
+	
+	self
+		assert: 42
+		equals: ([SimulationContext runSimulated: [self error]]
+			on: Error
+			do: [:ex | ex resumeUnchecked: 42]).

--- a/packages/SimulationStudio-Tests-Base.package/SimulationContextTest.class/methodProperties.json
+++ b/packages/SimulationStudio-Tests-Base.package/SimulationContextTest.class/methodProperties.json
@@ -11,6 +11,7 @@
 		"testCustomizationLevel" : "ct 3/5/2021 19:24",
 		"testCustomize" : "ct 3/5/2021 19:25",
 		"testDecustomize" : "ct 3/5/2021 19:25",
+		"testExceptionHandlerAroundSimulator" : "ct 1/23/2022 01:19",
 		"testInsertEnsure" : "ct 3/24/2021 23:48",
 		"testInsertEnsureWithError" : "ct 3/24/2021 23:49",
 		"testInsertOnDo" : "ct 3/24/2021 23:52",

--- a/packages/SimulationStudio-Tests-Sandbox.package/SandboxKernelTest.class/class/expectedFailureGroups.st
+++ b/packages/SimulationStudio-Tests-Sandbox.package/SandboxKernelTest.class/class/expectedFailureGroups.st
@@ -4,6 +4,9 @@ expectedFailureGroups
 	| groups |
 	groups := super expectedFailureGroups.
 	
+	groups at: #SimulationContextTest put: ((groups at: #SimulationContextTest ifAbsent: [{}]) , {
+		#testExceptionHandlerAroundSimulator flag: #todo. "breaks out the sandbox!"}).
+	
 	groups at: #WriteBarrierTest put: ((groups at: #WriteBarrierTest ifAbsent: [{}]) , {
 		#testMutateWideSymbolUsingPrivateAtPut flag: #todo. "sandbox-sensitive method lookup not yet implemented. This test uses become primitives to create guineaPig ..."}).
 	

--- a/packages/SimulationStudio-Tests-Sandbox.package/SandboxKernelTest.class/methodProperties.json
+++ b/packages/SimulationStudio-Tests-Sandbox.package/SandboxKernelTest.class/methodProperties.json
@@ -1,6 +1,6 @@
 {
 	"class" : {
-		"expectedFailureGroups" : "ct 3/24/2021 20:33",
+		"expectedFailureGroups" : "ct 1/23/2022 01:52",
 		"testGroups" : "ct 3/14/2021 20:10" },
 	"instance" : {
 		"basicPerformTest:on:do:" : "ct 11/13/2021 16:05",


### PR DESCRIPTION
- Align `SimulationContext >> #runSimulated:contextAtEachStep:` to recent updates in Trunk EHS engine (b7c45a35b726454e952a96b3b74c71cafb6447aa)
- `SimulationContext`: add missing override patches for `#tempAt:[put:]`, fix `#size` (1097417)
- Provide extra accessors on `LimitSimulator`; make SimulatorLimitExceeded resumable (e647ad7)

