### PR TITLE
Hooks (`#canSimulateYourself` & `#failPrimitiveWith:`)

### DIFF
--- a/packages/SimulationStudio-Base.package/Context.extension/instance/canSimulateYourself.st
+++ b/packages/SimulationStudio-Base.package/Context.extension/instance/canSimulateYourself.st
@@ -1,0 +1,5 @@
+*SimulationStudio-Base-testing
+canSimulateYourself
+	"Answer whether it is a valid operation to send #step to a thisContext instance of the receiver class."
+	
+	^ true

--- a/packages/SimulationStudio-Base.package/Context.extension/methodProperties.json
+++ b/packages/SimulationStudio-Base.package/Context.extension/methodProperties.json
@@ -5,6 +5,7 @@
 		"fromSimulationContext:" : "ct 3/5/2021 19:41",
 		"runSimulated:" : "ct 11/14/2021 02:06" },
 	"instance" : {
+		"canSimulateYourself" : "ct 2/12/2022 15:12",
 		"debug" : "ct 12/30/2021 14:28",
 		"insertEnsure:" : "ct 3/5/2021 19:35",
 		"insertOn:do:" : "ct 3/5/2021 19:35",

--- a/packages/SimulationStudio-Base.package/SimulationContext.class/instance/runSimulated.contextAtEachStep..st
+++ b/packages/SimulationStudio-Base.package/SimulationContext.class/instance/runSimulated.contextAtEachStep..st
@@ -29,7 +29,7 @@ runSimulated: aBlock contextAtEachStep: anotherBlock
 	
 	current := self customize: current.
 	
-	(anotherBlock numArgs = 0
+	((home canSimulateYourself and: [anotherBlock numArgs = 0])
 		ifTrue: ["optimized" [resume]]
 		ifFalse: ["stop execution on time, don't expose simulation details to caller"
 			[(current sender == ensure and: [current willReturn]) or: 

--- a/packages/SimulationStudio-Base.package/SimulationContext.class/methodProperties.json
+++ b/packages/SimulationStudio-Base.package/SimulationContext.class/methodProperties.json
@@ -33,7 +33,7 @@
 		"printOn:" : "ct 12/28/2020 15:49",
 		"push:" : "ct 12/28/2020 19:07",
 		"runSimulated:" : "ct 1/10/2021 20:14",
-		"runSimulated:contextAtEachStep:" : "ct 1/23/2022 01:22",
+		"runSimulated:contextAtEachStep:" : "ct 2/12/2022 15:48",
 		"runUntilErrorOrReturnFrom:" : "ct 3/28/2021 12:10",
 		"send:to:with:lookupIn:" : "ct 12/29/2021 14:52",
 		"shouldNotImplement:" : "ct 12/28/2020 15:29",

--- a/packages/SimulationStudio-Base.package/Simulator.class/instance/canContextSimulateItself.do..st
+++ b/packages/SimulationStudio-Base.package/Simulator.class/instance/canContextSimulateItself.do..st
@@ -1,0 +1,7 @@
+testing
+canContextSimulateItself: aContext do: aBlock
+	<capability: #canSimulateYourself>
+
+	^ nextSimulator
+		ifNotNil: [nextSimulator canContextSimulateItself: aContext do: aBlock]
+		ifNil: [aBlock value]

--- a/packages/SimulationStudio-Base.package/Simulator.class/instance/context.failPrimitiveWith.do..st
+++ b/packages/SimulationStudio-Base.package/Simulator.class/instance/context.failPrimitiveWith.do..st
@@ -1,0 +1,7 @@
+controlling
+context: aContext failPrimitiveWith: maybePrimFailToken do: aBlock
+	<capability: #failPrimitiveWith:>
+
+	^ nextSimulator
+		ifNotNil: [nextSimulator context: aContext failPrimitiveWith: maybePrimFailToken do: aBlock]
+		ifNil: [aBlock value: maybePrimFailToken]

--- a/packages/SimulationStudio-Base.package/Simulator.class/methodProperties.json
+++ b/packages/SimulationStudio-Base.package/Simulator.class/methodProperties.json
@@ -16,6 +16,7 @@
 		"allSimulators" : "ct 11/18/2021 22:45",
 		"basicSimulate:do:" : "ct 11/13/2021 17:07",
 		"basicSimulate:do:chain:" : "ct 11/13/2021 17:07",
+		"canContextSimulateItself:do:" : "ct 2/12/2022 15:17",
 		"context:activateMethod:withArgs:receiver:do:" : "ct 11/13/2021 15:45",
 		"context:blockReturnConstant:do:" : "ct 11/13/2021 15:19",
 		"context:callPrimitive:do:" : "ct 11/13/2021 15:40",

--- a/packages/SimulationStudio-Base.package/Simulator.class/methodProperties.json
+++ b/packages/SimulationStudio-Base.package/Simulator.class/methodProperties.json
@@ -30,6 +30,7 @@
 		"context:doPushActiveContext:" : "ct 11/12/2021 18:48",
 		"context:doPushReceiver:" : "ct 11/12/2021 18:49",
 		"context:doSingleRelease:" : "ct 1/12/2022 01:43",
+		"context:failPrimitiveWith:do:" : "ct 2/4/2022 20:59",
 		"context:jump:do:" : "ct 11/13/2021 15:41",
 		"context:jump:if:do:" : "ct 11/13/2021 15:41",
 		"context:lookupSelector:inClass:do:" : "ct 12/29/2021 01:54",

--- a/packages/SimulationStudio-Base.package/SimulatorContext.class/instance/canSimulateYourself.st
+++ b/packages/SimulationStudio-Base.package/SimulatorContext.class/instance/canSimulateYourself.st
@@ -1,0 +1,4 @@
+testing
+canSimulateYourself
+
+	^ simulator canContextSimulateItself: self do: [super canSimulateYourself]

--- a/packages/SimulationStudio-Base.package/SimulatorContext.class/instance/failPrimitiveWith..st
+++ b/packages/SimulationStudio-Base.package/SimulatorContext.class/instance/failPrimitiveWith..st
@@ -1,0 +1,4 @@
+system simulation
+failPrimitiveWith: maybePrimFailToken
+
+	^ simulator context: self failPrimitiveWith: maybePrimFailToken do: [:theMaybePrimFailToken | super failPrimitiveWith: theMaybePrimFailToken]

--- a/packages/SimulationStudio-Base.package/SimulatorContext.class/methodProperties.json
+++ b/packages/SimulationStudio-Base.package/SimulatorContext.class/methodProperties.json
@@ -11,6 +11,7 @@
 		"doDup" : "ct 11/12/2021 17:49",
 		"doPop" : "ct 11/12/2021 17:50",
 		"doPrimitive:method:receiver:args:" : "ct 11/13/2021 15:08",
+		"failPrimitiveWith:" : "ct 2/4/2022 20:58",
 		"initializeFrom:" : "ct 11/12/2021 23:27",
 		"jump:" : "ct 11/13/2021 15:13",
 		"jump:if:" : "ct 11/13/2021 15:13",

--- a/packages/SimulationStudio-Base.package/SimulatorContext.class/methodProperties.json
+++ b/packages/SimulationStudio-Base.package/SimulatorContext.class/methodProperties.json
@@ -6,6 +6,7 @@
 		"blockReturnConstant:" : "ct 11/13/2021 15:13",
 		"blockReturnTop" : "ct 11/12/2021 17:49",
 		"callPrimitive:" : "ct 11/13/2021 15:13",
+		"canSimulateYourself" : "ct 2/12/2022 15:29",
 		"directedSuperSend:numArgs:" : "ct 11/13/2021 15:13",
 		"doDup" : "ct 11/12/2021 17:49",
 		"doPop" : "ct 11/12/2021 17:50",

--- a/packages/SimulationStudio-Tests-Base.package/SimulationKernelTest.class/instance/basicPerformTest.st
+++ b/packages/SimulationStudio-Tests-Base.package/SimulationKernelTest.class/instance/basicPerformTest.st
@@ -6,7 +6,7 @@ basicPerformTest
 	
 	self
 		basicPerformTest: testCase
-		on: (Error, Halt), TestResult failure, UnhandledError
+		on: TestResult failure, TestResult allErrors, UnhandledError "just to be sure"
 		do: [:ex | exception := ex].
 	
 	self

--- a/packages/SimulationStudio-Tests-Base.package/SimulationKernelTest.class/methodProperties.json
+++ b/packages/SimulationStudio-Tests-Base.package/SimulationKernelTest.class/methodProperties.json
@@ -11,7 +11,7 @@
 		"testSelectorsFromGroups:" : "ct 1/7/2022 18:56",
 		"wantsToTest:" : "ct 3/5/2021 16:50" },
 	"instance" : {
-		"basicPerformTest" : "ct 12/27/2021 00:16",
+		"basicPerformTest" : "ct 2/12/2022 15:45",
 		"basicPerformTest:on:do:" : "ct 11/12/2021 19:37",
 		"contextClass" : "ct 3/14/2021 16:10",
 		"defaultTimeout" : "ct 12/27/2021 00:33",


### PR DESCRIPTION
- Make `#runSimulated:contextAtEachStep:` aware of contexts that don't `#canSimulateYourself` (23ea16c9290bc2a67b3441c3286d2b444a51011b)

- Catch Warnings in simulation kernel tests (4b65b18f9da444579f845bdcf357aa025a9bacbe)

- Add simulator capability `#failPrimitiveWith:` (ac5784b8cd682518f37baabe24d4dbd8045e8cc0)