### PR TITLE
Tracking

### DIFF
--- a/packages/SimulationStudio-Support.package/ProtoObject.extension/instance/trackingFrom.argAt..st
+++ b/packages/SimulationStudio-Support.package/ProtoObject.extension/instance/trackingFrom.argAt..st
@@ -1,0 +1,4 @@
+*SimulationStudio-Support-tracking
+trackingFrom: aContext argAt: argIndex
+
+	^ TrackedObject tracking: self from: aContext argAt: argIndex

--- a/packages/SimulationStudio-Support.package/ProtoObject.extension/instance/trackingFrom.instVarAt..st
+++ b/packages/SimulationStudio-Support.package/ProtoObject.extension/instance/trackingFrom.instVarAt..st
@@ -1,0 +1,4 @@
+*SimulationStudio-Support-tracking
+trackingFrom: aContext instVarAt: instVarIndex
+
+	^ TrackedObject tracking: self from: aContext instVarAt: instVarIndex

--- a/packages/SimulationStudio-Support.package/ProtoObject.extension/instance/trackingFrom.tempVarAt..st
+++ b/packages/SimulationStudio-Support.package/ProtoObject.extension/instance/trackingFrom.tempVarAt..st
@@ -1,0 +1,4 @@
+*SimulationStudio-Support-tracking
+trackingFrom: aContext tempVarAt: tempVarIndex
+
+	^ TrackedObject tracking: self from: aContext tempVarAt: tempVarIndex

--- a/packages/SimulationStudio-Support.package/ProtoObject.extension/instance/trackingReceiverFrom..st
+++ b/packages/SimulationStudio-Support.package/ProtoObject.extension/instance/trackingReceiverFrom..st
@@ -1,0 +1,4 @@
+*SimulationStudio-Support-tracking
+trackingReceiverFrom: aContext
+
+	^ TrackedObject trackingReceiver: self from: aContext

--- a/packages/SimulationStudio-Support.package/ProtoObject.extension/instance/untracking.st
+++ b/packages/SimulationStudio-Support.package/ProtoObject.extension/instance/untracking.st
@@ -1,0 +1,4 @@
+*SimulationStudio-Support-tracking
+untracking
+
+	^ self

--- a/packages/SimulationStudio-Support.package/ProtoObject.extension/methodProperties.json
+++ b/packages/SimulationStudio-Support.package/ProtoObject.extension/methodProperties.json
@@ -1,0 +1,9 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"trackingFrom:argAt:" : "ct 3/21/2022 22:53",
+		"trackingFrom:instVarAt:" : "ct 3/21/2022 22:35",
+		"trackingFrom:tempVarAt:" : "ct 3/21/2022 22:34",
+		"trackingReceiverFrom:" : "ct 3/21/2022 22:56",
+		"untracking" : "ct 3/21/2022 23:04" } }

--- a/packages/SimulationStudio-Support.package/ProtoObject.extension/properties.json
+++ b/packages/SimulationStudio-Support.package/ProtoObject.extension/properties.json
@@ -1,0 +1,2 @@
+{
+	"name" : "ProtoObject" }

--- a/packages/SimulationStudio-Support.package/TrackedObject.class/class/for..st
+++ b/packages/SimulationStudio-Support.package/TrackedObject.class/class/for..st
@@ -1,0 +1,4 @@
+instance creation
+for: anObject
+
+	^ self new xxxtrackedObject: anObject

--- a/packages/SimulationStudio-Support.package/TrackedObject.class/class/tracking.from.argAt..st
+++ b/packages/SimulationStudio-Support.package/TrackedObject.class/class/tracking.from.argAt..st
@@ -1,0 +1,5 @@
+instance creation
+tracking: anObject from: aContext argAt: argIndex
+
+	^ (self for: anObject)
+		xxxtrackFrom: aContext argAt: argIndex

--- a/packages/SimulationStudio-Support.package/TrackedObject.class/class/tracking.from.instVarAt..st
+++ b/packages/SimulationStudio-Support.package/TrackedObject.class/class/tracking.from.instVarAt..st
@@ -1,0 +1,5 @@
+instance creation
+tracking: anObject from: aContext instVarAt: tempIndex
+
+	^ (self for: anObject)
+		xxxtrackFrom: aContext instVarAt: tempIndex

--- a/packages/SimulationStudio-Support.package/TrackedObject.class/class/tracking.from.tempVarAt..st
+++ b/packages/SimulationStudio-Support.package/TrackedObject.class/class/tracking.from.tempVarAt..st
@@ -1,0 +1,5 @@
+instance creation
+tracking: anObject from: aContext tempVarAt: tempIndex
+
+	^ (self for: anObject)
+		xxxtrackFrom: aContext tempVarAt: tempIndex

--- a/packages/SimulationStudio-Support.package/TrackedObject.class/class/trackingReceiver.from..st
+++ b/packages/SimulationStudio-Support.package/TrackedObject.class/class/trackingReceiver.from..st
@@ -1,0 +1,5 @@
+instance creation
+trackingReceiver: anObject from: aContext
+
+	^ (self for: anObject)
+		xxxtrackReceiverFrom: aContext

--- a/packages/SimulationStudio-Support.package/TrackedObject.class/instance/doesNotUnderstand..st
+++ b/packages/SimulationStudio-Support.package/TrackedObject.class/instance/doesNotUnderstand..st
@@ -1,0 +1,4 @@
+dynamic forwarding
+doesNotUnderstand: aMessage
+
+	^ aMessage sendTo: object

--- a/packages/SimulationStudio-Support.package/TrackedObject.class/instance/trackingFrom.argAt..st
+++ b/packages/SimulationStudio-Support.package/TrackedObject.class/instance/trackingFrom.argAt..st
@@ -1,0 +1,5 @@
+tracking
+trackingFrom: aContext argAt: argIndex
+
+	^ self xxxcopy
+		xxxtrackFrom: aContext argAt: argIndex

--- a/packages/SimulationStudio-Support.package/TrackedObject.class/instance/trackingFrom.instVarAt..st
+++ b/packages/SimulationStudio-Support.package/TrackedObject.class/instance/trackingFrom.instVarAt..st
@@ -1,0 +1,5 @@
+tracking
+trackingFrom: aContext instVarAt: instVarIndex
+
+	^ self xxxcopy
+		xxxtrackFrom: aContext instVarAt: instVarIndex

--- a/packages/SimulationStudio-Support.package/TrackedObject.class/instance/trackingFrom.tempVarAt..st
+++ b/packages/SimulationStudio-Support.package/TrackedObject.class/instance/trackingFrom.tempVarAt..st
@@ -1,0 +1,5 @@
+tracking
+trackingFrom: aContext tempVarAt: tempVarIndex
+
+	^ self xxxcopy
+		xxxtrackFrom: aContext tempVarAt: tempVarIndex

--- a/packages/SimulationStudio-Support.package/TrackedObject.class/instance/trackingReceiverFrom..st
+++ b/packages/SimulationStudio-Support.package/TrackedObject.class/instance/trackingReceiverFrom..st
@@ -1,0 +1,5 @@
+tracking
+trackingReceiverFrom: aContext
+
+	^ self xxxcopy
+		xxxtrackReceiverFrom: aContext

--- a/packages/SimulationStudio-Support.package/TrackedObject.class/instance/untracking.st
+++ b/packages/SimulationStudio-Support.package/TrackedObject.class/instance/untracking.st
@@ -1,0 +1,4 @@
+accessing
+untracking
+
+	^ object

--- a/packages/SimulationStudio-Support.package/TrackedObject.class/instance/xxxcopy.st
+++ b/packages/SimulationStudio-Support.package/TrackedObject.class/instance/xxxcopy.st
@@ -1,0 +1,4 @@
+copying
+xxxcopy
+
+	^ self xxxshallowCopy xxxpostCopy

--- a/packages/SimulationStudio-Support.package/TrackedObject.class/instance/xxxpostCopy.st
+++ b/packages/SimulationStudio-Support.package/TrackedObject.class/instance/xxxpostCopy.st
@@ -1,0 +1,4 @@
+copying
+xxxpostCopy
+
+	tempVars := tempVars copy.

--- a/packages/SimulationStudio-Support.package/TrackedObject.class/instance/xxxshallowCopy.st
+++ b/packages/SimulationStudio-Support.package/TrackedObject.class/instance/xxxshallowCopy.st
@@ -1,0 +1,5 @@
+copying
+xxxshallowCopy
+	<primitive: 148 error: ec>
+
+	^ Error signal: 'primitive failed'

--- a/packages/SimulationStudio-Support.package/TrackedObject.class/instance/xxxtrackFrom.argAt..st
+++ b/packages/SimulationStudio-Support.package/TrackedObject.class/instance/xxxtrackFrom.argAt..st
@@ -1,0 +1,6 @@
+accessing
+xxxtrackFrom: aContext argAt: argIndex
+
+	((args ifNil: [args := IdentityDictionary new])
+		at: aContext ifAbsentPut: [Set new])
+			add: argIndex.

--- a/packages/SimulationStudio-Support.package/TrackedObject.class/instance/xxxtrackFrom.instVarAt..st
+++ b/packages/SimulationStudio-Support.package/TrackedObject.class/instance/xxxtrackFrom.instVarAt..st
@@ -1,0 +1,6 @@
+accessing
+xxxtrackFrom: aContext instVarAt: instVarIndex
+
+	((instVars ifNil: [instVars := IdentityDictionary new])
+		at: aContext ifAbsentPut: [Set new])
+			add: instVarIndex.

--- a/packages/SimulationStudio-Support.package/TrackedObject.class/instance/xxxtrackFrom.tempVarAt..st
+++ b/packages/SimulationStudio-Support.package/TrackedObject.class/instance/xxxtrackFrom.tempVarAt..st
@@ -1,0 +1,6 @@
+accessing
+xxxtrackFrom: aContext tempVarAt: tempVarIndex
+
+	((tempVars ifNil: [tempVars := IdentityDictionary new])
+		at: aContext ifAbsentPut: [Set new])
+			add: tempVarIndex.

--- a/packages/SimulationStudio-Support.package/TrackedObject.class/instance/xxxtrackReceiverFrom..st
+++ b/packages/SimulationStudio-Support.package/TrackedObject.class/instance/xxxtrackReceiverFrom..st
@@ -1,0 +1,5 @@
+accessing
+xxxtrackReceiverFrom: aContext
+
+	(receivers ifNil: [receivers := IdentitySet new])
+		add: aContext.

--- a/packages/SimulationStudio-Support.package/TrackedObject.class/instance/xxxtrackedObject..st
+++ b/packages/SimulationStudio-Support.package/TrackedObject.class/instance/xxxtrackedObject..st
@@ -1,0 +1,4 @@
+accessing
+xxxtrackedObject: anObject
+
+	object := anObject.

--- a/packages/SimulationStudio-Support.package/TrackedObject.class/instance/xxxtrackedObject.st
+++ b/packages/SimulationStudio-Support.package/TrackedObject.class/instance/xxxtrackedObject.st
@@ -1,0 +1,4 @@
+accessing
+xxxtrackedObject
+
+	^ object

--- a/packages/SimulationStudio-Support.package/TrackedObject.class/methodProperties.json
+++ b/packages/SimulationStudio-Support.package/TrackedObject.class/methodProperties.json
@@ -1,0 +1,23 @@
+{
+	"class" : {
+		"for:" : "ct 3/21/2022 22:24",
+		"tracking:from:argAt:" : "ct 3/21/2022 22:54",
+		"tracking:from:instVarAt:" : "ct 3/21/2022 22:33",
+		"tracking:from:tempVarAt:" : "ct 3/21/2022 22:26",
+		"trackingReceiver:from:" : "ct 3/21/2022 22:57" },
+	"instance" : {
+		"doesNotUnderstand:" : "ct 3/21/2022 22:26",
+		"trackingFrom:argAt:" : "ct 3/21/2022 22:53",
+		"trackingFrom:instVarAt:" : "ct 3/21/2022 22:35",
+		"trackingFrom:tempVarAt:" : "ct 3/21/2022 22:34",
+		"trackingReceiverFrom:" : "ct 3/21/2022 22:55",
+		"untracking" : "ct 3/21/2022 23:04",
+		"xxxcopy" : "ct 3/21/2022 22:28",
+		"xxxpostCopy" : "ct 3/21/2022 22:29",
+		"xxxshallowCopy" : "ct 3/21/2022 22:28",
+		"xxxtrackFrom:argAt:" : "ct 3/21/2022 22:53",
+		"xxxtrackFrom:instVarAt:" : "ct 3/21/2022 22:36",
+		"xxxtrackFrom:tempVarAt:" : "ct 3/21/2022 22:35",
+		"xxxtrackReceiverFrom:" : "ct 3/21/2022 22:56",
+		"xxxtrackedObject" : "ct 3/21/2022 22:24",
+		"xxxtrackedObject:" : "ct 3/21/2022 22:25" } }

--- a/packages/SimulationStudio-Support.package/TrackedObject.class/properties.json
+++ b/packages/SimulationStudio-Support.package/TrackedObject.class/properties.json
@@ -1,0 +1,18 @@
+{
+	"category" : "SimulationStudio-Support",
+	"classinstvars" : [
+		 ],
+	"classvars" : [
+		 ],
+	"commentStamp" : "",
+	"instvars" : [
+		"object",
+		"tempVars",
+		"instVars",
+		"args",
+		"receivers" ],
+	"name" : "TrackedObject",
+	"pools" : [
+		 ],
+	"super" : "ProtoObject",
+	"type" : "normal" }

--- a/packages/SimulationStudio-Support.package/TrackingSimulator.class/instance/context.activateMethod.withArgs.receiver.do..st
+++ b/packages/SimulationStudio-Support.package/TrackingSimulator.class/instance/context.activateMethod.withArgs.receiver.do..st
@@ -1,0 +1,13 @@
+controlling
+context: aContext activateMethod: aCompiledMethod withArgs: arguments receiver: receiver do: aBlock
+
+	| newContext |
+	newContext := super context: aContext activateMethod: aCompiledMethod withArgs: arguments receiver: receiver do: aBlock.
+	
+	newContext arguments withIndexDo: [:arg :index |
+		newContext at: index put:
+			(self tracking: arg fromArgAt: index in: newContext)].
+	"newContext receiver:
+		(self trackingReceiver: newContext receiver in: newContext)."
+	
+	^ newContext

--- a/packages/SimulationStudio-Support.package/TrackingSimulator.class/instance/context.doPrimitive.method.receiver.args.do..st
+++ b/packages/SimulationStudio-Support.package/TrackingSimulator.class/instance/context.doPrimitive.method.receiver.args.do..st
@@ -1,0 +1,11 @@
+controlling
+context: aContext doPrimitive: primitiveIndex method: aCompiledMethod receiver: receiver args: arguments do: aBlock
+
+	self flag: #todo. "Do this only for non-simulated prims!"
+	^ super
+		context: aContext
+		doPrimitive: primitiveIndex
+		method: aCompiledMethod
+		receiver: receiver untracking
+		args: (arguments collect: [:argument | argument untracking])
+		do: aBlock

--- a/packages/SimulationStudio-Support.package/TrackingSimulator.class/instance/context.popIntoReceiverVariable.do..st
+++ b/packages/SimulationStudio-Support.package/TrackingSimulator.class/instance/context.popIntoReceiverVariable.do..st
@@ -1,0 +1,9 @@
+instruction processing
+context: aContext popIntoReceiverVariable: offset do: aBlock
+
+	| top result |
+	top := self tracking: aContext pop fromInstVarAt: offset + 1 in: aContext.
+	result := aContext simulatedObject: aContext receiver instVarAt: offset + 1 put: top.
+	^ (aContext object: result eqeq: top)
+		ifTrue: [aContext]
+		ifFalse: [result]

--- a/packages/SimulationStudio-Support.package/TrackingSimulator.class/instance/context.popIntoTemporaryVariable.do..st
+++ b/packages/SimulationStudio-Support.package/TrackingSimulator.class/instance/context.popIntoTemporaryVariable.do..st
@@ -1,0 +1,7 @@
+instruction processing
+context: aContext popIntoTemporaryVariable: offset do: aBlock
+
+	^ aContext
+		at: offset + 1 put:
+			(self tracking: aContext pop fromTempVarAt: offset + 1 in: aContext);
+		yourself

--- a/packages/SimulationStudio-Support.package/TrackingSimulator.class/instance/context.send.super.numArgs.do..st
+++ b/packages/SimulationStudio-Support.package/TrackingSimulator.class/instance/context.send.super.numArgs.do..st
@@ -1,0 +1,12 @@
+controlling
+context: aContext send: selector super: superFlag numArgs: numArgs do: aBlock
+
+	"0"numArgs to: numArgs do: [:i |
+		aContext at: aContext stackPtr - i put:
+			(aContext at: aContext stackPtr - i) untracking].
+	^ super
+		context: aContext
+		send: selector
+		super: superFlag
+		numArgs: numArgs
+		do: aBlock

--- a/packages/SimulationStudio-Support.package/TrackingSimulator.class/instance/context.sendSpecial.numArgs.do..st
+++ b/packages/SimulationStudio-Support.package/TrackingSimulator.class/instance/context.sendSpecial.numArgs.do..st
@@ -1,0 +1,4 @@
+controlling
+context: aContext sendSpecial: selector numArgs: numArgs do: aBlock
+
+	^ aContext send: selector super: false numArgs: numArgs

--- a/packages/SimulationStudio-Support.package/TrackingSimulator.class/instance/context.storeIntoReceiverVariable.do..st
+++ b/packages/SimulationStudio-Support.package/TrackingSimulator.class/instance/context.storeIntoReceiverVariable.do..st
@@ -1,0 +1,9 @@
+instruction processing
+context: aContext storeIntoReceiverVariable: offset do: aBlock
+
+	| top result |
+	top := self tracking: aContext top fromInstVarAt: offset + 1 in: aContext.
+	result := aContext simulatedObject: aContext receiver instVarAt: offset + 1 put: top.
+	^ (aContext object: result eqeq: top)
+		ifTrue: [aContext]
+		ifFalse: [result]

--- a/packages/SimulationStudio-Support.package/TrackingSimulator.class/instance/context.storeIntoTemporaryVariable.do..st
+++ b/packages/SimulationStudio-Support.package/TrackingSimulator.class/instance/context.storeIntoTemporaryVariable.do..st
@@ -1,0 +1,7 @@
+instruction processing
+context: aContext storeIntoTemporaryVariable: offset do: aBlock
+
+	^ aContext
+		at: offset + 1 put:
+			(self tracking: aContext top fromTempVarAt: offset + 1 in: aContext);
+		yourself

--- a/packages/SimulationStudio-Support.package/TrackingSimulator.class/instance/tracking.fromArgAt.in..st
+++ b/packages/SimulationStudio-Support.package/TrackingSimulator.class/instance/tracking.fromArgAt.in..st
@@ -1,0 +1,4 @@
+private
+tracking: anObject fromArgAt: argIndex in: aContext
+
+	^ anObject trackingFrom: aContext argAt: argIndex

--- a/packages/SimulationStudio-Support.package/TrackingSimulator.class/instance/tracking.fromInstVarAt.in..st
+++ b/packages/SimulationStudio-Support.package/TrackingSimulator.class/instance/tracking.fromInstVarAt.in..st
@@ -1,0 +1,4 @@
+private
+tracking: anObject fromInstVarAt: instVarIndex in: aContext
+
+	^ anObject trackingFrom: aContext instVarAt: instVarIndex

--- a/packages/SimulationStudio-Support.package/TrackingSimulator.class/instance/tracking.fromTempVarAt.in..st
+++ b/packages/SimulationStudio-Support.package/TrackingSimulator.class/instance/tracking.fromTempVarAt.in..st
@@ -1,0 +1,4 @@
+private
+tracking: anObject fromTempVarAt: tempVarIndex in: aContext
+
+	^ anObject trackingFrom: aContext tempVarAt: tempVarIndex

--- a/packages/SimulationStudio-Support.package/TrackingSimulator.class/instance/trackingReceiver.in..st
+++ b/packages/SimulationStudio-Support.package/TrackingSimulator.class/instance/trackingReceiver.in..st
@@ -1,0 +1,4 @@
+private
+trackingReceiver: anObject in: aContext
+
+	^ anObject trackingReceiverFrom: aContext

--- a/packages/SimulationStudio-Support.package/TrackingSimulator.class/methodProperties.json
+++ b/packages/SimulationStudio-Support.package/TrackingSimulator.class/methodProperties.json
@@ -1,0 +1,16 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"context:activateMethod:withArgs:receiver:do:" : "ct 3/21/2022 23:08",
+		"context:doPrimitive:method:receiver:args:do:" : "ct 3/21/2022 23:14",
+		"context:popIntoReceiverVariable:do:" : "ct 3/21/2022 22:46",
+		"context:popIntoTemporaryVariable:do:" : "ct 3/21/2022 22:46",
+		"context:send:super:numArgs:do:" : "ct 3/21/2022 23:29",
+		"context:sendSpecial:numArgs:do:" : "ct 3/21/2022 23:24",
+		"context:storeIntoReceiverVariable:do:" : "ct 3/21/2022 22:41",
+		"context:storeIntoTemporaryVariable:do:" : "ct 3/21/2022 22:43",
+		"tracking:fromArgAt:in:" : "ct 3/21/2022 22:59",
+		"tracking:fromInstVarAt:in:" : "ct 3/21/2022 22:35",
+		"tracking:fromTempVarAt:in:" : "ct 3/21/2022 22:34",
+		"trackingReceiver:in:" : "ct 3/21/2022 22:55" } }

--- a/packages/SimulationStudio-Support.package/TrackingSimulator.class/properties.json
+++ b/packages/SimulationStudio-Support.package/TrackingSimulator.class/properties.json
@@ -1,0 +1,14 @@
+{
+	"category" : "SimulationStudio-Support",
+	"classinstvars" : [
+		 ],
+	"classvars" : [
+		 ],
+	"commentStamp" : "",
+	"instvars" : [
+		 ],
+	"name" : "TrackingSimulator",
+	"pools" : [
+		 ],
+	"super" : "Simulator",
+	"type" : "normal" }


### PR DESCRIPTION
Concerns https://github.com/hpi-swa-lab/squeak-tracedebugger/issues/74

Usage:

```smalltalk
TrackingSimulator debug: [
	| x y |
	x := Morph new.
	y := x].
BasicInspector openOn: y.
```

Next steps:

- [ ] Revise tracking and untracking places - currently, receiver et al. are not tracked properly
- [ ] Discuss need for transparent proxy
- [ ] Proper support for primitives

Further work (can go into separate PRs):

- [ ] Discuss API for displaying tracked information and usage in production (for TDB, this approach would be _slow_)
- [ ] We could also use this to explain side effects from a sandbox or TDB retracing
- [ ] Discuss target package and category