### PR TITLE
sandbox: fix primitiveExecuteMethod[ArgsArray] for quick return methods

### DIFF
--- a/packages/SimulationStudio-Sandbox.package/Sandbox2.class/instance/context.doPrimitive.method.receiver.args.do..st
+++ b/packages/SimulationStudio-Sandbox.package/Sandbox2.class/instance/context.doPrimitive.method.receiver.args.do..st
@@ -145,6 +145,22 @@ context: aContext doPrimitive: primitiveIndex method: aCompiledMethod receiver: 
 			[185 "primitiveExitCriticalSection"] -> [^ self context: aContext activateOperationForbidden: 'Critical section primitives are disabled in sandbox simulation'].
 			[186 "primitiveEnterCriticalSection"] -> [^ self context: aContext activateOperationForbidden: 'Critical section primitives are disabled in sandbox simulation'].
 			[187 "primitiveTestAndSetOwnershipOfCriticalSection"] -> [^ self context: aContext activateOperationForbidden: 'Critical section primitives are disabled in sandbox simulation'].
+			[188 "primitiveExecuteMethodArgsArray"] -> [
+				"Prevent Context from executing quick methods directly without dispatching via this method"
+				| method |
+				arguments size >= 2 ifTrue: [
+					(aContext objectClass: (method := arguments last)) isCompiledMethodClass
+						and: [method isQuick ifTrue:
+							[^ aContext doPrimitive: method primitive method: method receiver: receiver args:
+								(arguments atLast: 2)]]]].
+			[189 "primitiveExecuteMethod"] -> [
+				"Prevent Context from executing quick methods directly without dispatching via this method"
+				| method |
+				arguments size = 1 ifTrue: [
+					(aContext objectClass: (method := arguments last)) isCompiledMethodClass
+						and: [method isQuick ifTrue:
+							[^ aContext doPrimitive: method primitive method: method receiver: receiver args:
+								arguments allButLast]]]].
 			[195 "primitiveFindNextUnwindContext"] -> [
 				"Note: Usually, this primitive will not be called for thisContext during simulation. However, if that's what the client is after, don't fall for it but use the image implementation."
 				^ self context: aContext primitiveFailTokenFor: nil].

--- a/packages/SimulationStudio-Sandbox.package/Sandbox2.class/methodProperties.json
+++ b/packages/SimulationStudio-Sandbox.package/Sandbox2.class/methodProperties.json
@@ -15,7 +15,7 @@
 		"context:activateOperationForbidden:" : "ct 11/13/2021 01:04",
 		"context:canBeImmutable:" : "ct 11/12/2021 23:54",
 		"context:doNamedPrimitiveIn:for:withArgs:" : "ct 5/2/2022 21:43",
-		"context:doPrimitive:method:receiver:args:do:" : "ct 6/3/2022 17:14",
+		"context:doPrimitive:method:receiver:args:do:" : "ct 7/1/2022 18:43",
 		"context:doPrimitiveHash:receiver:args:" : "ct 11/12/2021 23:56",
 		"context:doPrimitiveNew:receiver:args:" : "ct 11/12/2021 23:55",
 		"context:doPrimitiveSetImmutability:receiver:args:" : "ct 12/29/2021 17:38",

--- a/packages/SimulationStudio-Sandbox.package/SandboxContext.class/instance/doPrimitive.method.receiver.args..st
+++ b/packages/SimulationStudio-Sandbox.package/SandboxContext.class/instance/doPrimitive.method.receiver.args..st
@@ -145,6 +145,22 @@ doPrimitive: primitiveIndex method: meth receiver: rcvr args: arguments
 			[185 "primitiveExitCriticalSection"] -> [^ self activateOperationForbidden: 'Critical section primitives are disabled in sandbox simulation'].
 			[186 "primitiveEnterCriticalSection"] -> [^ self activateOperationForbidden: 'Critical section primitives are disabled in sandbox simulation'].
 			[187 "primitiveTestAndSetOwnershipOfCriticalSection"] -> [^ self activateOperationForbidden: 'Critical section primitives are disabled in sandbox simulation'].
+			[188 "primitiveExecuteMethodArgsArray"] -> [
+				"Prevent Context from executing quick methods directly without dispatching via this method"
+				| method |
+				arguments size >= 2 ifTrue: [
+					(self objectClass: (method := arguments last)) isCompiledMethodClass
+						and: [method isQuick ifTrue:
+							[^ self doPrimitive: method primitive method: method receiver: rcvr args:
+								(arguments atLast: 2)]]]].
+			[189 "primitiveExecuteMethod"] -> [
+				"Prevent Context from executing quick methods directly without dispatching via this method"
+				| method |
+				arguments size = 1 ifTrue: [
+					(self objectClass: (method := arguments last)) isCompiledMethodClass
+						and: [method isQuick ifTrue:
+							[^ self doPrimitive: method primitive method: method receiver: rcvr args:
+								arguments allButLast]]]].
 			[195 "primitiveFindNextUnwindContext"] -> [
 				"Note: Usually, this primitive will not be called for thisContext during simulation. However, if that's what the client is after, don't fall for it but use the image implementation."
 				^ self class primitiveFailTokenFor: nil].

--- a/packages/SimulationStudio-Sandbox.package/SandboxContext.class/methodProperties.json
+++ b/packages/SimulationStudio-Sandbox.package/SandboxContext.class/methodProperties.json
@@ -6,7 +6,7 @@
 		"activateOperationForbidden:" : "ct 3/3/2021 17:55",
 		"canBeImmutable:" : "ct 3/22/2021 23:47",
 		"doNamedPrimitiveIn:for:withArgs:" : "ct 5/10/2022 16:24",
-		"doPrimitive:method:receiver:args:" : "ct 6/3/2022 17:14",
+		"doPrimitive:method:receiver:args:" : "ct 7/1/2022 18:46",
 		"doPrimitiveHash:receiver:args:" : "ct 3/22/2021 18:51",
 		"doPrimitiveNew:receiver:args:" : "ct 3/4/2021 20:16",
 		"doPrimitiveSetImmutability:receiver:args:" : "ct 12/29/2021 17:37",

--- a/packages/SimulationStudio-Tests-Sandbox.package/SandboxTest.class/instance/testExecuteQuickMethod.st
+++ b/packages/SimulationStudio-Tests-Sandbox.package/SandboxTest.class/instance/testExecuteQuickMethod.st
@@ -1,0 +1,13 @@
+tests
+testExecuteQuickMethod
+
+	| object |
+	object := MessageSend new.
+	object receiver: nil.
+	
+	self sandboxClass evaluate: [
+		object receiver: self.
+		self assert: self equals: (object executeMethod: object class >> #receiver).
+		self assert: self equals: (object withArgs: #() executeMethod: object class >> #receiver)].
+	
+	self assert: nil equals: object receiver.

--- a/packages/SimulationStudio-Tests-Sandbox.package/SandboxTest.class/methodProperties.json
+++ b/packages/SimulationStudio-Tests-Sandbox.package/SandboxTest.class/methodProperties.json
@@ -5,6 +5,7 @@
 		"sandboxClass" : "ct 11/13/2021 16:05",
 		"testBitBlt" : "ct 11/13/2021 00:00",
 		"testCannotUsurpExecution" : "ct 11/13/2021 00:01",
+		"testExecuteQuickMethod" : "ct 7/1/2022 18:45",
 		"testFindSelectors" : "ct 12/27/2021 00:32",
 		"testIdentityHashConstant" : "ct 11/13/2021 00:01",
 		"testMemoryHashes" : "ct 11/13/2021 00:01",


### PR DESCRIPTION
The default simulator would execute a quick return method for primitive 188/189 directly, taking away any chance from us to customize the quick return primitive. Override these primitives to handle the edge case properly.